### PR TITLE
Fix release to call release_notes.sh regardless of directory to call from

### DIFF
--- a/.buildscripts/release.sh
+++ b/.buildscripts/release.sh
@@ -1,9 +1,11 @@
 echo Input version number using semantic versioning, e.g. '0.1.2'
 read tag
 
+# Gets the working directory of the file to use when calling release-notes.sh
+wd="$( cd "$( dirname "$0" )" && pwd )"
 echo Generating release notes...
 echo Creating tag...
-./.buildscripts/release-notes.sh | git tag -a $tag --file -
+$wd/release-notes.sh | git tag -a $tag --file -
 
 echo "Push release tag? [y/n]"
 read push


### PR DESCRIPTION
Fixes #85